### PR TITLE
Agent api refactor 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,179 @@
-pyproject.lock
-poetry.lock
-./idea
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
 .env
-dist
-app.log
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# .env file
+.env
+*/.env
+**/.env

--- a/dria_agent/agent/__init__.py
+++ b/dria_agent/agent/__init__.py
@@ -1,1 +1,1 @@
-from .agent import ToolCallingAgent, ToolCallingAgentFactory
+from .agent import ToolCallingAgent

--- a/examples/exchange_rate_example.py
+++ b/examples/exchange_rate_example.py
@@ -1,0 +1,127 @@
+from dria_agent.agent import ToolCallingAgentFactory
+from dria_agent.tools.tool import tool
+import requests
+from datetime import datetime, timedelta
+from typing import Dict, Tuple
+
+# Cache to store exchange rate responses
+# Structure: {base_currency: (data, expiry_timestamp)}
+_CACHE: Dict[str, Tuple[dict, datetime]] = {}
+# Cache duration - 24 hours since the free API updates once per day
+CACHE_DURATION = timedelta(hours=24)
+
+
+def _get_cached_rates(base_currency: str) -> dict:
+    """
+    Get exchange rates from cache or fetch from API if needed.
+    
+    Args:
+    - base_currency: The base currency code
+    
+    Returns:
+    - Dictionary containing exchange rate data
+    """
+    base_currency = base_currency.upper()
+    now = datetime.now()
+    
+    # Check if we have a valid cached response
+    if base_currency in _CACHE:
+        data, expiry = _CACHE[base_currency]
+        if now < expiry:
+            return data
+    
+    # If no valid cache, fetch from API
+    url = f"https://open.er-api.com/v6/latest/{base_currency}"
+    response = requests.get(url)
+    data = response.json()
+    
+    if data["result"] != "success":
+        raise Exception(f"Error fetching exchange rate: {data.get('error-type', 'Unknown error')}")
+    
+    # Cache the response
+    _CACHE[base_currency] = (data, now + CACHE_DURATION)
+    return data
+
+
+@tool
+def get_exchange_rate(base_currency: str, target_currency: str) -> dict:
+    """
+    Get the exchange rate between two currencies using the Exchange Rate API.
+
+    Args:
+    - base_currency: The base currency code (e.g., 'USD', 'EUR')
+    - target_currency: The target currency code (e.g., 'JPY', 'GBP')
+
+    Returns:
+    - A dictionary containing the exchange rate information
+        dict keys:
+            - base_currency (str): The base currency code
+            - target_currency (str): The target currency code
+            - rate (float): The exchange rate
+            - last_update (str): Last update time in UTC
+    """
+    base_currency = base_currency.upper()
+    target_currency = target_currency.upper()
+    
+    # Get rates from cache or API
+    data = _get_cached_rates(base_currency)
+    
+    return {
+        "base_currency": base_currency,
+        "target_currency": target_currency,
+        "rate": data["rates"][target_currency],
+        "last_update": data["time_last_update_utc"]
+    }
+
+
+@tool
+def convert_currency(amount: float, from_currency: str, to_currency: str) -> dict:
+    """
+    Convert an amount from one currency to another.
+
+    Args:
+    - amount: The amount to convert
+    - from_currency: The currency to convert from (e.g., 'USD', 'EUR')
+    - to_currency: The currency to convert to (e.g., 'JPY', 'GBP')
+
+    Returns:
+    - A dictionary containing the conversion result
+        dict keys:
+            - from_amount (float): Original amount
+            - from_currency (str): Original currency
+            - to_amount (float): Converted amount
+            - to_currency (str): Target currency
+            - rate (float): Exchange rate used
+    """
+    # Get exchange rate
+    exchange_info = get_exchange_rate(from_currency, to_currency)
+    rate = exchange_info["rate"]
+    
+    converted_amount = amount * rate
+    
+    return {
+        "from_amount": amount,
+        "from_currency": from_currency,
+        "to_amount": converted_amount,
+        "to_currency": to_currency,
+        "rate": rate
+    }
+
+
+# Create an inference engine with the exchange rate tools
+agent = ToolCallingAgentFactory.create(
+    tools=[get_exchange_rate, convert_currency],
+    backend="ollama"
+)
+
+# Example 1: Get exchange rate
+query = "What's the current exchange rate from USD to EUR?"
+execution = agent.run(query, print_results=True)
+
+# Example 2: Convert currency
+query = "Convert 100 USD to JPY"
+execution = agent.run(query, print_results=True)
+
+# Example 3: Multiple conversions
+query = "How much is 50 EUR in USD and GBP?"
+execution = agent.run(query, print_results=True)

--- a/examples/exchange_rate_example.py
+++ b/examples/exchange_rate_example.py
@@ -1,4 +1,4 @@
-from dria_agent.agent import ToolCallingAgentFactory
+from dria_agent.agent import ToolCallingAgent
 from dria_agent.tools.tool import tool
 import requests
 from datetime import datetime, timedelta
@@ -109,7 +109,7 @@ def convert_currency(amount: float, from_currency: str, to_currency: str) -> dic
 
 
 # Create an inference engine with the exchange rate tools
-agent = ToolCallingAgentFactory.create(
+agent = ToolCallingAgent(
     tools=[get_exchange_rate, convert_currency],
     backend="ollama"
 )

--- a/examples/maps_example.py
+++ b/examples/maps_example.py
@@ -1,11 +1,10 @@
-from dria_agent.agent import ToolCallingAgentFactory
+from dria_agent.agent import ToolCallingAgent
 from dria_agent.tools import APPLE_TOOLS
 
 # Create an inference engine with the available tool(s).
-agent = ToolCallingAgentFactory.create(tools=APPLE_TOOLS, backend="ollama")
+agent = ToolCallingAgent(tools=APPLE_TOOLS, backend="ollama")
 
 
 # --- Example 1: Simple tool usage ---
-# query = "Show me how can I get to barbaros bulvarı by motorbike"
-query = "Please open Discord App"
+query = "Show me how can I get to barbaros bulvarı by motorbike"
 execution = agent.run(query, print_results=True)

--- a/examples/math_example.py
+++ b/examples/math_example.py
@@ -1,8 +1,8 @@
-from dria_agent.agent import ToolCallingAgentFactory
+from dria_agent.agent import ToolCallingAgent
 from dria_agent.tools import MATH_TOOLS
 
 # Create an inference engine with the available tool(s).
-agent = ToolCallingAgentFactory.create(tools=MATH_TOOLS, backend="mlx")
+agent = ToolCallingAgent(tools=MATH_TOOLS, backend="mlx")
 
 
 # --- Example 1: Simple tool usage ---

--- a/examples/meetup_example.py
+++ b/examples/meetup_example.py
@@ -1,4 +1,4 @@
-from dria_agent.agent import ToolCallingAgentFactory
+from dria_agent.agent import ToolCallingAgent
 from dria_agent.tools.tool import tool
 
 
@@ -62,7 +62,7 @@ def add_to_reminders(reminder_text: str) -> bool:
     return True
 
 
-agent = ToolCallingAgentFactory.create(
+agent = ToolCallingAgent(
     tools=[add_to_reminders, check_availability, make_appointment]
 )
 


### PR DESCRIPTION
Changed the agent api from `ToolCallingAgentFactory.create(...` to `ToolCallingAgent(...` without changing functionality. So now this:
```python
agent = ToolCallingAgentFactory.create(tools=MATH_TOOLS, backend="mlx")
```
is this:
```python
agent = ToolCallingAgent(tools=MATH_TOOLS, backend="mlx")
```

I think it's cleaner API